### PR TITLE
[optimize] optimize getAvailable's performance on large weight map

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <commons-math3.version>3.6.1</commons-math3.version>
+        <jmh.version>1.21</jmh.version>
     </properties>
 
     <parent>
@@ -113,6 +114,20 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
             <version>${commons-math3.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/github/phantomthief/failover/impl/WeightFailover.java
+++ b/src/main/java/com/github/phantomthief/failover/impl/WeightFailover.java
@@ -217,7 +217,14 @@ public class WeightFailover<T> implements Failover<T>, Closeable {
 
     @Override
     public List<T> getAvailable() {
-        return getAvailable(MAX_VALUE);
+        List<T> result = new ArrayList<>(currentWeightMap.size());
+        for (Entry<T, Integer> entry : currentWeightMap.entrySet()) {
+            T item = entry.getKey();
+            if (entry.getValue() > 0 && filter.test(item)) {
+                result.add(item);
+            }
+        }
+        return result;
     }
 
     @Override

--- a/src/test/java/com/github/phantomthief/failover/impl/WeightFailoverJmhTest.java
+++ b/src/test/java/com/github/phantomthief/failover/impl/WeightFailoverJmhTest.java
@@ -1,0 +1,53 @@
+package com.github.phantomthief.failover.impl;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
+
+/**
+ * @author lijie
+ * Created on 2019-02-17
+ */
+@BenchmarkMode(Mode.Throughput)
+@Fork(1)
+@Warmup(iterations = 2, time = 2)
+@Measurement(iterations = 2, time = 2)
+@State(Scope.Benchmark)
+public class WeightFailoverJmhTest {
+
+    @Param({"5", "20", "100", "200", "1000"})
+    public int size;
+
+    private WeightFailover<String> failover;
+
+    @Setup
+    public void init() {
+        Builder<String, Integer> builder = ImmutableMap.builder();
+        for (int i = 0; i < size; ++i) {
+            builder.put("key" + i, i);
+        }
+        failover = WeightFailover.<String> newGenericBuilder()
+                .checker(it -> true, 1)
+                .build(builder.build());
+    }
+
+    @Benchmark
+    public void getAvailableOpitmized() {
+        failover.getAvailable();
+    }
+
+    @Benchmark
+    public void getAvailable() {
+        failover.getAvailable(size);
+    }
+}

--- a/src/test/java/com/github/phantomthief/failover/impl/WeightFailoverTest.java
+++ b/src/test/java/com/github/phantomthief/failover/impl/WeightFailoverTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
@@ -57,6 +58,9 @@ class WeightFailoverTest {
             });
             sleepUninterruptibly(10, MILLISECONDS);
         }
+
+        assertEquals(new HashSet<>(failover.getAvailable()),
+                new HashSet<>(failover.getAvailable(original.size())));
         System.out.println(getCount);
         System.out.println(result);
     }
@@ -102,6 +106,8 @@ class WeightFailoverTest {
             assertNotEquals(available, "1");
             sleepUninterruptibly(10, MILLISECONDS);
         }
+        assertEquals(new HashSet<>(failover.getAvailable()),
+                new HashSet<>(failover.getAvailable(original.size())));
         System.out.println(getCount);
         System.out.println(result);
     }

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -5,11 +5,12 @@
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %level \(%F:%L\) - %msg %n</pattern>
         </encoder>
-        <includeCallerData>true</includeCallerData>
     </appender>
 
     <root>
         <appender-ref ref="stdout"/>
         <level value="all"/>
     </root>
+
+    <logger name="ch.qos.logback" level="WARN"/>
 </configuration>


### PR DESCRIPTION
WeightFailover's getAvailable(Void) method has performance bottleneck on large weight map (abount 1000 items), this mr give a quick fix, see the JMH test result below.

JHM test result:
```
Benchmark                                    (size)   Mode  Cnt         Score   Error  Units
WeightFailoverJmhTest.getAvailable                5  thrpt    2   4359626.695          ops/s
WeightFailoverJmhTest.getAvailable               20  thrpt    2    622380.305          ops/s
WeightFailoverJmhTest.getAvailable              100  thrpt    2     53702.517          ops/s
WeightFailoverJmhTest.getAvailable              200  thrpt    2     15754.184          ops/s
WeightFailoverJmhTest.getAvailable             1000  thrpt    2      1203.037          ops/s
WeightFailoverJmhTest.getAvailableOpitmized       5  thrpt    2  12405064.633          ops/s
WeightFailoverJmhTest.getAvailableOpitmized      20  thrpt    2   3932523.281          ops/s
WeightFailoverJmhTest.getAvailableOpitmized     100  thrpt    2    768910.546          ops/s
WeightFailoverJmhTest.getAvailableOpitmized     200  thrpt    2    369643.381          ops/s
WeightFailoverJmhTest.getAvailableOpitmized    1000  thrpt    2     78877.113          ops/s
```