### PR TITLE
Add PartitionFailover.

### DIFF
--- a/src/main/java/com/github/phantomthief/failover/impl/PartitionFailover.java
+++ b/src/main/java/com/github/phantomthief/failover/impl/PartitionFailover.java
@@ -137,8 +137,7 @@ public class PartitionFailover<T> implements Failover<T>, Closeable {
         resEntry.concurrency.updateAndGet(oldValue -> Math.max(oldValue + 1, 1));
     }
 
-    // weak consistency
-    private void replaceDownResource(T object) {
+    private synchronized void replaceDownResource(T object) {
         ResEntry<T>[] resourceRefCopy = resources;
         if (resourceRefCopy.length == totalResourceSize) {
             // so there is no more resource in weightFailover

--- a/src/main/java/com/github/phantomthief/failover/impl/PartitionFailover.java
+++ b/src/main/java/com/github/phantomthief/failover/impl/PartitionFailover.java
@@ -1,0 +1,286 @@
+package com.github.phantomthief.failover.impl;
+
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toList;
+
+import java.io.Closeable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.github.phantomthief.failover.Failover;
+
+/**
+ * @author huangli
+ * Created on 2019-12-10
+ */
+public class PartitionFailover<T> implements Failover<T>, Closeable {
+
+    private final WeightFailover<T> weightFailover;
+    private final long maxExternalPoolIdleMillis;
+    private final int totalResourceSize;
+    private volatile ResEntry<T>[] resources;
+
+    @SuppressWarnings("checkstyle:VisibilityModifier")
+    private static class ResEntry<T> {
+        final T object;
+        final int initWeight;
+
+        volatile long lastReturnNanoTime;
+        AtomicInteger concurrency;
+
+        ResEntry(T object, int initWeight, int initConcurrency) {
+            this.object = object;
+            this.initWeight = initWeight;
+            this.concurrency = new AtomicInteger(initConcurrency);
+        }
+
+    }
+
+    @SuppressWarnings("checkstyle:VisibilityModifier")
+    private static class ResEntryEx<T> extends ResEntry<T> {
+        double scoreWeight;
+
+        ResEntryEx(T object, int initWeight, int initConcurrency) {
+            super(object, initWeight, initConcurrency);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    PartitionFailover(PartitionFailoverBuilder<T> partitionFailoverBuilder,
+            WeightFailover<T> weightFailover) {
+        this.weightFailover = weightFailover;
+        this.totalResourceSize = weightFailover.getAll().size();
+        this.maxExternalPoolIdleMillis = partitionFailoverBuilder.maxExternalPoolIdleMillis;
+        int corePartitionSize = partitionFailoverBuilder.corePartitionSize;
+        List<T> available = weightFailover.getAvailable(corePartitionSize);
+        this.resources = new ResEntry[corePartitionSize];
+        for (int i = 0; i < corePartitionSize; i++) {
+            T one = available.get(i);
+            resources[i] = new ResEntry<>(one, weightFailover.initWeight(one), 0);
+        }
+    }
+
+    private ResEntryEx<T>[] deepCopyResource() {
+        ResEntry<T>[] refCopy = resources;
+        @SuppressWarnings("unchecked")
+        ResEntryEx<T>[] copy = new ResEntryEx[refCopy.length];
+        for (int i = 0; i < refCopy.length; i++) {
+            ResEntry<T> res = refCopy[i];
+            ResEntryEx<T> resEx = new ResEntryEx<>(res.object, res.initWeight, res.concurrency.get());
+            resEx.lastReturnNanoTime = res.lastReturnNanoTime;
+            copy[i] = resEx;
+        }
+        return copy;
+    }
+
+    @Override
+    public List<T> getAll() {
+        return weightFailover.getAll();
+    }
+
+    @Override
+    public void fail(@Nonnull T object) {
+        weightFailover.fail(object);
+        subtractConcurrency(object);
+        if (weightFailover.currentWeight(object) <= 0) {
+            replaceDownResource(object);
+        }
+    }
+
+    @Override
+    public void down(@Nonnull T object) {
+        weightFailover.down(object);
+        subtractConcurrency(object);
+        replaceDownResource(object);
+    }
+
+    @Override
+    public void success(@Nonnull T object) {
+        weightFailover.success(object);
+        subtractConcurrency(object);
+    }
+
+    @Nullable
+    private ResEntry<T> lookup(Object object) {
+        ResEntry<T>[] refCopy = resources;
+        for (ResEntry<T> res : refCopy) {
+            if (res.object == object) {
+                return res;
+            }
+        }
+        return null;
+    }
+
+    private void subtractConcurrency(@Nonnull T object) {
+        ResEntry<T> resEntry = lookup(object);
+        if (resEntry == null) {
+            return;
+        }
+        resEntry.lastReturnNanoTime = System.nanoTime();
+        resEntry.concurrency.updateAndGet(oldValue -> Math.max(oldValue - 1, 0));
+    }
+
+    private void addConcurrency(@Nonnull T object) {
+        ResEntry<T> resEntry = lookup(object);
+        if (resEntry == null) {
+            return;
+        }
+        resEntry.lastReturnNanoTime = System.nanoTime();
+        resEntry.concurrency.updateAndGet(oldValue -> Math.max(oldValue + 1, 1));
+    }
+
+    // weak consistency
+    private void replaceDownResource(T object) {
+        ResEntry<T>[] resourceRefCopy = resources;
+        if (resourceRefCopy.length == totalResourceSize) {
+            // so there is no more resource in weightFailover
+            return;
+        }
+        @SuppressWarnings("unchecked")
+        ResEntry<T>[] newList = new ResEntry[resourceRefCopy.length];
+        int index = -1;
+        for (int i = 0; i < resourceRefCopy.length; i++) {
+            newList[i] = resourceRefCopy[i];
+            if (newList[i].object == object) {
+                index = i;
+            }
+        }
+        if (index == -1) {
+            // maybe replaced by another thread
+            return;
+        }
+        List<T> excludes = Stream.of(resourceRefCopy).map(r -> r.object).collect(toList());
+        T newOne = weightFailover.getOneAvailableExclude(excludes);
+        if (newOne == null) {
+            //no more available
+            return;
+        }
+        newList[index] = new ResEntry<>(newOne, weightFailover.initWeight(newOne), 0);
+        resources = newList;
+    }
+
+
+    @Nullable
+    @Override
+    public T getOneAvailable() {
+        return getOneAvailableExclude(Collections.emptyList());
+    }
+
+    @Nullable
+    @Override
+    public T getOneAvailableExclude(Collection<T> exclusions) {
+        // we use recent resource when:
+        // 1, tps of caller is slow (all concurrency is 0)
+        boolean noCallInProgress = true;
+        // 2, all resources are healthy (all currentWeight == initWeight)
+        boolean allResIsHealthy = true;
+        // 3, at least there is one call returned in recent
+        boolean hasRecentReturnedCall = false;
+        final long nowNanoTime = System.nanoTime();
+        final ResEntryEx<T>[] resourcesCopy = deepCopyResource();
+
+        double sumOfScoreWeight = 0;
+        int recentestIndex = 0;
+        long maxTime = 0;
+
+        for (int i = 0; i < resourcesCopy.length; i++) {
+            ResEntryEx<T> res = resourcesCopy[i];
+            int currentWeight = weightFailover.currentWeight(res.object);
+            res.scoreWeight = 1.0 * currentWeight / (res.concurrency.get() + 1);
+            if (res.scoreWeight < 0) {
+                // something wrong
+                res.scoreWeight = 0;
+            }
+            if (!exclusions.contains(res.object)) {
+                sumOfScoreWeight += res.scoreWeight;
+                if (maxTime < res.lastReturnNanoTime) {
+                    maxTime = res.lastReturnNanoTime;
+                    recentestIndex = i;
+                }
+            }
+            if (res.concurrency.get() > 0) {
+                noCallInProgress = false;
+            }
+            if (currentWeight != res.initWeight) {
+                allResIsHealthy = false;
+            }
+            long elapseMillis = (nowNanoTime - res.lastReturnNanoTime) / (1000 * 1000);
+            if (elapseMillis >= 0 && elapseMillis < maxExternalPoolIdleMillis) {
+                hasRecentReturnedCall = true;
+            }
+        }
+        T one;
+        if (maxExternalPoolIdleMillis > 0 && noCallInProgress && allResIsHealthy && hasRecentReturnedCall) {
+            one = resourcesCopy[recentestIndex].object;
+        } else {
+            one = selectByScore(resourcesCopy, exclusions, sumOfScoreWeight);
+        }
+        if (one != null) {
+            addConcurrency(one);
+        }
+        return one;
+    }
+
+    private static <T> T selectByScore(ResEntryEx<T>[] resourcesCopy, Collection<T> exclusions, double sumOfScoreWeight) {
+        if (sumOfScoreWeight <= 0) {
+            // all down
+            return null;
+        }
+        double selectValue = ThreadLocalRandom.current().nextDouble(sumOfScoreWeight);
+        double x = 0;
+        for (ResEntryEx<T> res : resourcesCopy) {
+            if (exclusions.contains(res.object)) {
+                continue;
+            }
+            x += res.scoreWeight;
+            if (selectValue < x) {
+                return res.object;
+            }
+        }
+        // something wrong or there are float precision problem
+        return resourcesCopy[0].object;
+    }
+
+    @Override
+    public List<T> getAvailable() {
+        ResEntry<T>[] resourceRefCopy = resources;
+        if (resourceRefCopy.length == totalResourceSize) {
+            return weightFailover.getAvailable();
+        } else {
+            return Stream.of(resourceRefCopy)
+                    .filter(r -> weightFailover.currentWeight(r.object) > 0)
+                    .map(r -> r.object)
+                    .collect(collectingAndThen(toList(), Collections::unmodifiableList));
+        }
+    }
+
+    @Override
+    public Set<T> getFailed() {
+        return weightFailover.getFailed();
+    }
+
+    @Override
+    public void close() {
+        weightFailover.close();
+    }
+
+    @Override
+    public List<T> getAvailable(int n) {
+        // we don't know which resource is used, so this method is not supported
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<T> getAvailableExclude(Collection<T> exclusions) {
+        // we don't know which resource is used, so this method is not supported
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/com/github/phantomthief/failover/impl/PartitionFailoverBuilder.java
+++ b/src/main/java/com/github/phantomthief/failover/impl/PartitionFailoverBuilder.java
@@ -1,0 +1,166 @@
+package com.github.phantomthief.failover.impl;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+
+import com.github.phantomthief.util.ThrowableFunction;
+import com.github.phantomthief.util.ThrowablePredicate;
+
+@SuppressWarnings({"checkstyle:VisibilityModifier", "checkstyle:HiddenField"})
+public class PartitionFailoverBuilder<T> {
+
+    private WeightFailoverBuilder<T> weightFailoverBuilder = new WeightFailoverBuilder<>();
+
+    int corePartitionSize;
+
+    long maxExternalPoolIdleMillis;
+
+    public static <T> PartitionFailoverBuilder<T> newBuilder() {
+        return new PartitionFailoverBuilder<>();
+    }
+
+    @Nonnull
+    public PartitionFailover<T> build(Collection<T> original) {
+        ensure();
+        WeightFailover<T> weightFailover = weightFailoverBuilder.build(original);
+        return new PartitionFailover<>(this, weightFailover);
+    }
+
+    @Nonnull
+    public PartitionFailover<T> build(Collection<T> original, int initWeight) {
+        ensure();
+        WeightFailover<T> weightFailover = weightFailoverBuilder.build(original, initWeight);
+        return new PartitionFailover<>(this, weightFailover);
+    }
+
+    @Nonnull
+    public PartitionFailover<T> build(Map<T, Integer> original) {
+        ensure();
+        WeightFailover<T> weightFailover = weightFailoverBuilder.build(original);
+        return new PartitionFailover<>(this, weightFailover);
+    }
+
+    private void ensure() {
+        checkArgument(corePartitionSize > 0, "corePartitionSize has to be positive");
+    }
+
+    @CheckReturnValue
+    @Nonnull
+    public PartitionFailoverBuilder<T> corePartitionSize(int corePartitionSize) {
+        this.corePartitionSize = corePartitionSize;
+        return this;
+    }
+
+    @CheckReturnValue
+    @Nonnull
+    public PartitionFailoverBuilder<T> reuseRecentResource(long maxExternalPoolIdleMillis) {
+        this.maxExternalPoolIdleMillis = maxExternalPoolIdleMillis;
+        return this;
+    }
+
+    //-------------------------methods delegate to weightFailoverBuilder below---------------------
+
+    @CheckReturnValue
+    @Nonnull
+    public PartitionFailoverBuilder<T> name(String value) {
+        weightFailoverBuilder.name(value);
+        return this;
+    }
+
+    @CheckReturnValue
+    @Nonnull
+    public PartitionFailoverBuilder<T> autoAddOnMissing(int weight) {
+        weightFailoverBuilder.autoAddOnMissing(weight);
+        return this;
+    }
+
+    @CheckReturnValue
+    @Nonnull
+    public PartitionFailoverBuilder<T> onMinWeight(Consumer<T> listener) {
+        weightFailoverBuilder.onMinWeight(listener);
+        return this;
+    }
+
+    @CheckReturnValue
+    @Nonnull
+    public PartitionFailoverBuilder<T> onRecovered(Consumer<T> listener) {
+        weightFailoverBuilder.onRecovered(listener);
+        return this;
+    }
+
+    @CheckReturnValue
+    @Nonnull
+    public PartitionFailoverBuilder<T> minWeight(int value) {
+        weightFailoverBuilder.minWeight(value);
+        return this;
+    }
+
+    @CheckReturnValue
+    @Nonnull
+    public PartitionFailoverBuilder<T> failReduceRate(double rate) {
+        weightFailoverBuilder.failReduceRate(rate);
+        return this;
+    }
+
+    @CheckReturnValue
+    @Nonnull
+    public PartitionFailoverBuilder<T> failReduce(int weight) {
+        weightFailoverBuilder.failReduce(weight);
+        return this;
+    }
+
+    @CheckReturnValue
+    @Nonnull
+    public PartitionFailoverBuilder<T> successIncreaseRate(double rate) {
+        weightFailoverBuilder.successIncreaseRate(rate);
+        return this;
+    }
+
+    @CheckReturnValue
+    @Nonnull
+    public PartitionFailoverBuilder<T> successIncrease(int weight) {
+        weightFailoverBuilder.successIncrease(weight);
+        return this;
+    }
+
+    @CheckReturnValue
+    @Nonnull
+    public PartitionFailoverBuilder<T> checkDuration(long time, TimeUnit unit) {
+        weightFailoverBuilder.checkDuration(time, unit);
+        return this;
+    }
+
+    @CheckReturnValue
+    @Nonnull
+    public PartitionFailoverBuilder<T> filter(@Nonnull Predicate<T> filter) {
+        weightFailoverBuilder.filter(filter);
+        return this;
+    }
+
+    @CheckReturnValue
+    @Nonnull
+    public PartitionFailoverBuilder<T>
+            checker(@Nonnull ThrowableFunction<? super T, Double, Throwable> failChecker) {
+        weightFailoverBuilder.checker(failChecker);
+        return this;
+    }
+
+    @CheckReturnValue
+    @Nonnull
+    public PartitionFailoverBuilder<T> checker(
+            @Nonnull ThrowablePredicate<? super T, Throwable> failChecker,
+            @Nonnegative double recoveredInitRate) {
+        weightFailoverBuilder.checker(failChecker, recoveredInitRate);
+        return this;
+    }
+
+}

--- a/src/main/java/com/github/phantomthief/failover/impl/WeightFailover.java
+++ b/src/main/java/com/github/phantomthief/failover/impl/WeightFailover.java
@@ -257,6 +257,13 @@ public class WeightFailover<T> implements Failover<T>, Closeable {
         return getAvailable(MAX_VALUE, exclusions);
     }
 
+    @Nullable
+    @Override
+    public T getOneAvailableExclude(Collection<T> exclusions) {
+        List<T> result = getAvailable(1, exclusions);
+        return result.isEmpty() ? null : result.get(0);
+    }
+
     @Override
     public List<T> getAvailable(int n) {
         return getAvailable(n, emptySet());
@@ -338,8 +345,12 @@ public class WeightFailover<T> implements Failover<T>, Closeable {
                 .collect(toSet());
     }
 
-    double currentWeight(T obj) {
+    int currentWeight(T obj) {
         return currentWeightMap.get(obj);
+    }
+
+    int initWeight(T obj) {
+        return initWeightMap.get(obj);
     }
 
     @Override

--- a/src/main/java/com/github/phantomthief/failover/impl/WeightFailoverBuilder.java
+++ b/src/main/java/com/github/phantomthief/failover/impl/WeightFailoverBuilder.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import com.github.phantomthief.util.ThrowableFunction;
 import com.github.phantomthief.util.ThrowablePredicate;
 
+@SuppressWarnings({"checkstyle:VisibilityModifier", "checkstyle:HiddenField"})
 public class WeightFailoverBuilder<T> {
 
     private static final Logger logger = getLogger(WeightFailoverBuilder.class);
@@ -44,7 +45,7 @@ public class WeightFailoverBuilder<T> {
     int minWeight = 0;
     Integer weightOnMissingNode;
     String name;
-    
+
     Predicate<T> filter;
 
     @CheckReturnValue

--- a/src/test/java/com/github/phantomthief/failover/impl/PartitionFailoverTest.java
+++ b/src/test/java/com/github/phantomthief/failover/impl/PartitionFailoverTest.java
@@ -1,0 +1,474 @@
+package com.github.phantomthief.failover.impl;
+
+import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.github.phantomthief.failover.Failover;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * @author huangli
+ * Created on 2019-12-12
+ */
+class PartitionFailoverTest<T> {
+
+    private Res r0;
+    private Res r1;
+    private Res r2;
+    private Res r3;
+    private Res r4;
+
+    @BeforeEach
+    public void setup() {
+        r0 = new Res(0);
+        r1 = new Res(1);
+        r2 = new Res(2);
+        r3 = new Res(3);
+        r4 = new Res(4);
+    }
+
+    private static class Res {
+        private final int index;
+        private AtomicLong invokeCount = new AtomicLong();
+        private boolean invokeDownWhenFail = false;
+        private volatile long executeTime = 0;
+        private volatile double failRate = 0;
+
+        public Res(int index) {
+            this.index = index;
+        }
+
+        public boolean execute(Failover<Res> failover, long sleepTime) {
+            if (sleepTime > 0) {
+                try {
+                    Thread.sleep(sleepTime);
+                } catch (InterruptedException e) {
+                }
+            }
+            boolean fail = ThreadLocalRandom.current().nextDouble() < failRate;
+            if (fail) {
+                if (invokeDownWhenFail) {
+                    failover.down(this);
+                } else {
+                    failover.fail(this);
+                }
+            } else {
+                failover.success(this);
+            }
+            invokeCount.incrementAndGet();
+            return !fail;
+        }
+
+        public boolean execute(Failover<Res> failover) {
+            return execute(failover, executeTime);
+        }
+    }
+
+    @Test
+    public void testPoolWithPartition() throws Exception {
+        testPool1(3);
+        setup();
+        testPool2(3);
+        setup();
+        testPool3(3);
+        setup();
+        testPool4(3);
+
+        setup();
+        testPool1(1);
+        setup();
+        testPool2(1);
+        setup();
+        testPool3(1);
+        setup();
+        testPool4(1);
+    }
+
+    @Test
+    public void testPoolWithoutPartition() throws Exception {
+        testPool1(5);
+        setup();
+        testPool2(5);
+        setup();
+        testPool3(5);
+        setup();
+        testPool4(5);
+    }
+
+    private void testPool1(int coreSize) {
+        PartitionFailover<Res> failover = PartitionFailoverBuilder.<Res> newBuilder()
+                .checker(r -> 1.0)
+                .corePartitionSize(coreSize)
+                .reuseRecentResource(50)
+                .build(Arrays.asList(r0, r1, r2, r3, r4));
+        Res res = failover.getOneAvailable();
+        res.execute(failover);
+        int lastIndex = res.index;
+        for (int i = 0; i < 100; i++) {
+            res = failover.getOneAvailable();
+            assertEquals(lastIndex, res.index);
+            res.execute(failover);
+        }
+        failover.close();
+    }
+
+    private void testPool2(int coreSize) throws Exception {
+        PartitionFailover<Res> failover = PartitionFailoverBuilder.<Res> newBuilder()
+                .checker(r -> 1.0)
+                .corePartitionSize(coreSize)
+                .reuseRecentResource(5000)
+                .build(Arrays.asList(r0, r1, r2, r3, r4), 50);
+        final Res res = failover.getOneAvailable();
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        Thread t = new Thread(() -> {
+            countDownLatch.countDown();
+            res.execute(failover, 1000);
+        });
+        t.start();
+        countDownLatch.await();
+        HashSet<Res> selectResSet = new HashSet<>();
+        final int loopCount = 5000;
+        for (int i = 0; i < loopCount; i++) {
+            Res r = failover.getOneAvailable();
+            r.execute(failover);
+            selectResSet.add(r);
+        }
+        assertEquals(coreSize, selectResSet.size());
+        for (Res r : selectResSet) {
+            long totalWeight = 100 * coreSize - 50;
+            if (r == res) {
+                double expectCount = 50.0 / totalWeight * loopCount;
+                assertEquals(expectCount, r.invokeCount.get(), expectCount * 0.1);
+            } else {
+                double expectCount = 100.0 / totalWeight * loopCount;
+                assertEquals(expectCount, r.invokeCount.get(), expectCount * 0.1);
+            }
+        }
+        t.interrupt();
+        failover.close();
+    }
+
+    private void testPool3(int coreSize) {
+        PartitionFailover<Res> failover = PartitionFailoverBuilder.<Res> newBuilder()
+                .checker(r -> 1.0)
+                .corePartitionSize(coreSize)
+                .reuseRecentResource(1)
+                .build(ImmutableMap.of(r0, 100, r1, 100, r2, 100, r3, 100, r4, 100));
+        HashSet<Res> selectResSet = new HashSet<>();
+        for (int i = 0; i < 100; i++) {
+            Res res = failover.getOneAvailable();
+            res.execute(failover);
+            sleepUninterruptibly(2, TimeUnit.MILLISECONDS);
+            selectResSet.add(res);
+        }
+        assertEquals(coreSize, selectResSet.size());
+        failover.close();
+    }
+
+    private void testPool4(int coreSize) {
+        PartitionFailover<Res> failover = PartitionFailoverBuilder.<Res> newBuilder()
+                .checker(r -> 1.0)
+                .corePartitionSize(coreSize)
+                .reuseRecentResource(0)
+                .build(Arrays.asList(r0, r1, r2, r3, r4));
+        HashSet<Res> selectResSet = new HashSet<>();
+        for (int i = 0; i < 100; i++) {
+            Res res = failover.getOneAvailable();
+            res.execute(failover);
+            selectResSet.add(res);
+        }
+        assertEquals(coreSize, selectResSet.size());
+        failover.close();
+    }
+
+    @Test
+    public void testFailAndDown() {
+        testFailWithPartition();
+
+        setup();
+        r0.invokeDownWhenFail = true;
+        r1.invokeDownWhenFail = true;
+        r2.invokeDownWhenFail = true;
+        r3.invokeDownWhenFail = true;
+        r4.invokeDownWhenFail = true;
+        testFailWithPartition();
+
+        setup();
+        testFailWithoutPartition();
+
+        setup();
+        r0.invokeDownWhenFail = true;
+        r1.invokeDownWhenFail = true;
+        r2.invokeDownWhenFail = true;
+        r3.invokeDownWhenFail = true;
+        r4.invokeDownWhenFail = true;
+        testFailWithoutPartition();
+    }
+
+    private void testFailWithPartition() {
+        PartitionFailover<Res> failover = PartitionFailoverBuilder.<Res> newBuilder()
+                .checker(r -> 1.0)
+                .corePartitionSize(3)
+                .failReduceRate(0.5)
+                .reuseRecentResource(0)
+                .build(Arrays.asList(r0, r1, r2, r3, r4));
+
+        assertEquals(3, failover.getAvailable().size());
+        assertEquals(0, failover.getFailed().size());
+        {
+            Res res = failover.getOneAvailable();
+            res.execute(failover);
+            res.failRate = 1;
+        }
+        HashSet<Res> selectResSet = new HashSet<>();
+        for (int i = 0; i < 100; i++) {
+            Res res = failover.getOneAvailable();
+            res.execute(failover);
+            selectResSet.add(res);
+        }
+        //replaceDownResource
+        assertEquals(4, selectResSet.size());
+        assertEquals(3, failover.getAvailable().size());
+        assertEquals(1, failover.getFailed().size());
+
+        {
+            Res res = failover.getOneAvailable();
+            res.execute(failover);
+            res.failRate = 1;
+        }
+        selectResSet.clear();
+        for (int i = 0; i < 100; i++) {
+            Res res = failover.getOneAvailable();
+            res.execute(failover);
+            selectResSet.add(res);
+        }
+        //replaceDownResource
+        assertEquals(4, selectResSet.size());
+        assertEquals(3, failover.getAvailable().size());
+        assertEquals(2, failover.getFailed().size());
+
+        {
+            Res res = failover.getOneAvailable();
+            res.execute(failover);
+            res.failRate = 1;
+        }
+        selectResSet.clear();
+        for (int i = 0; i < 100; i++) {
+            Res res = failover.getOneAvailable();
+            res.execute(failover);
+            selectResSet.add(res);
+        }
+        // no more backup available resource
+        assertEquals(3, selectResSet.size());
+        assertEquals(2, failover.getAvailable().size());
+        assertEquals(3, failover.getFailed().size());
+
+        selectResSet.forEach(r -> r.failRate = 1);
+        selectResSet.clear();
+        for (int i = 0; i < 100; i++) {
+            Res res = failover.getOneAvailable();
+            if (res != null) {
+                res.execute(failover);
+                selectResSet.add(res);
+            }
+        }
+        assertEquals(2, selectResSet.size());
+        assertEquals(0, failover.getAvailable().size());
+        assertEquals(5, failover.getFailed().size());
+
+        failover.close();
+    }
+
+    private void testFailWithoutPartition() {
+        PartitionFailover<Res> failover = PartitionFailoverBuilder.<Res> newBuilder()
+                .checker(r -> 1.0)
+                .corePartitionSize(5)
+                .failReduceRate(0.5)
+                .reuseRecentResource(0)
+                .build(Arrays.asList(r0, r1, r2, r3, r4));
+
+        assertEquals(5, failover.getAvailable().size());
+        assertEquals(0, failover.getFailed().size());
+        {
+            Res res = failover.getOneAvailable();
+            res.execute(failover);
+            res.failRate = 1;
+        }
+        HashSet<Res> selectResSet = new HashSet<>();
+        for (int i = 0; i < 100; i++) {
+            Res res = failover.getOneAvailable();
+            res.execute(failover);
+            selectResSet.add(res);
+        }
+        //replaceDownResource
+        assertEquals(5, selectResSet.size());
+        assertEquals(4, failover.getAvailable().size());
+        assertEquals(1, failover.getFailed().size());
+
+        selectResSet.forEach(r -> r.failRate = 1);
+        selectResSet.clear();
+        for (int i = 0; i < 100; i++) {
+            Res res = failover.getOneAvailable();
+            if (res != null) {
+                res.execute(failover);
+                selectResSet.add(res);
+            }
+        }
+        assertEquals(4, selectResSet.size());
+        assertEquals(0, failover.getAvailable().size());
+        assertEquals(5, failover.getFailed().size());
+
+        failover.close();
+    }
+
+    @Test
+    public void testBadConcurrencyWithPartition() {
+        for (int i = 0; i < 10; i++) {
+            testBadConcurrencyWithoutPartition(3);
+            testBadConcurrencyWithoutPartition(1);
+        }
+    }
+
+    @Test
+    public void testBadConcurrencyWithoutPartition() {
+        for (int i = 0; i < 10; i++) {
+            testBadConcurrencyWithoutPartition(5);
+        }
+    }
+
+    private void testBadConcurrencyWithoutPartition(int coreSize) {
+        PartitionFailover<Res> failover = PartitionFailoverBuilder.<Res> newBuilder()
+                .checker(r -> 1.0)
+                .corePartitionSize(coreSize)
+                .reuseRecentResource(50)
+                .build(Arrays.asList(r0, r1, r2, r3, r4));
+        failover.down(r0);
+        if (coreSize == failover.getAll().size()) {
+            assertEquals(coreSize - 1, failover.getAvailable().size());
+        } else {
+            assertEquals(coreSize, failover.getAvailable().size());
+        }
+
+        failover.down(r1);
+        failover.down(r2);
+        failover.down(r3);
+        failover.down(r4);
+
+        assertEquals(0, failover.getAvailable().size());
+        assertEquals(5, failover.getFailed().size());
+
+        failover.close();
+    }
+
+    @Test
+    public void testGetOneAvailableExclude() {
+        testGetOneAvailableExclude(1);
+        testGetOneAvailableExclude(3);
+        testGetOneAvailableExclude(5);
+    }
+
+    private void testGetOneAvailableExclude(int coreSize) {
+        PartitionFailover<Res> failover = PartitionFailoverBuilder.<Res> newBuilder()
+                .checker(r -> 1.0)
+                .corePartitionSize(coreSize)
+                .reuseRecentResource(50)
+                .build(Arrays.asList(r0, r1, r2, r3, r4));
+        List<Res> list = new ArrayList<>();
+        for (int i = 0; i < coreSize + 1; i++) {
+            Res res = failover.getOneAvailableExclude(list);
+            if (i == coreSize) {
+                assertNull(res);
+            } else {
+                assertNotNull(res);
+                list.add(res);
+            }
+        }
+        failover.close();
+    }
+
+    @Test
+    public void testNoSupportedMethod() {
+        PartitionFailover<Res> failover = PartitionFailoverBuilder.<Res> newBuilder()
+                .checker(r -> 1.0)
+                .corePartitionSize(3)
+                .reuseRecentResource(50)
+                .build(Arrays.asList(r0, r1, r2, r3, r4));
+        assertThrows(UnsupportedOperationException.class, () -> failover.getAvailable(2));
+        assertThrows(UnsupportedOperationException.class, () -> failover.getAvailableExclude(emptyList()));
+    }
+
+    @Test
+    public void testConcurrency() throws Exception {
+        testConcurrency(3);
+        testConcurrency(5);
+    }
+
+    private void testConcurrency(int coreSize) throws Exception {
+        PartitionFailover<Res> failover = PartitionFailoverBuilder.<Res> newBuilder()
+                .checker(r -> 1.0)
+                .checkDuration(5, TimeUnit.MILLISECONDS)
+                .corePartitionSize(coreSize)
+                .reuseRecentResource(50)
+                .build(Arrays.asList(r0, r1, r2, r3, r4));
+        Res res = failover.getOneAvailable();
+        res.execute(failover);
+
+        Consumer<Res> fun = r -> r.failRate = r == res ? 0 : 0.05;
+        fun.accept(r0);
+        fun.accept(r1);
+        fun.accept(r2);
+        fun.accept(r3);
+        fun.accept(r4);
+        int threadCount = 50;
+        Thread[] thread = new Thread[threadCount];
+        AtomicBoolean stop = new AtomicBoolean(false);
+        AtomicBoolean fail = new AtomicBoolean(false);
+        for (int i = 0; i < threadCount; i++) {
+            thread[i] = new Thread(() -> {
+                while (!stop.get()) {
+                    List<Res> failed = new ArrayList<>();
+                    Res r = failover.getOneAvailableExclude(failed);
+                    while (r != null) {
+                        boolean ok = r.execute(failover);
+                        if (!ok) {
+                            failed.add(r);
+                            r = failover.getOneAvailableExclude(failed);
+                            if (r == null) {
+                                fail.set(true);
+                            }
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            });
+            thread[i].start();
+        }
+        Thread.sleep(1000);
+        stop.set(true);
+        for (int i = 0; i < threadCount; i++) {
+            thread[i].join();
+        }
+        assertFalse(fail.get());
+    }
+
+}


### PR DESCRIPTION
功能：
1、concurrency + weight 组合的策略，会同时考虑这两个因素。
2、当被调用资源很多的时候进行分区，使用一个子集，这样创建failover后如果要进行整体探活，就可以只探活一部分资源，另外如果资源下有连接池，有利于提升连接池的命中率。
3、当主调方tps较低(或被调方响应很快)的时候，支持优先使用最近使用过的资源（有选项开启或关闭），提升连接池命中率。
4、如果小池子有资源down，从整个大池子中再拿一个available来替换
5、子集的大小可以和整个集合相同

实现：
1、没有实现getAvailable(int n)/getAvailableExclude(Collection)方法，因为无法确定调用方接下来使用了哪个资源
2、getAvailable()返回分区后的子集
3、通过success、fail、down来减concurrency计数
4、没有锁，修改的时候copy on write
5、现在只有corePartitionSize，将来可以增加maxPartitionSize，并发度高的时候扩容，像线程池那样
6、getOneAvailable要考虑的因素有concurrency、当前权重（隐含访问失败的情况）、初始权重、最近访问时间等，目前简单分成两个分支处理。